### PR TITLE
Изолировать запуск кода студента в racket/sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ test:
 test-solutions:
 	composer exec phpunit -- --testsuite "Exercises"
 
+test-sandbox:
+	composer exec phpunit -- --testsuite "Sandbox"
+
 test-coverage:
 	XDEBUG_MODE=coverage php artisan test --coverage-clover build/logs/clover.xml
 

--- a/app/DTO/CheckResultData.php
+++ b/app/DTO/CheckResultData.php
@@ -21,6 +21,11 @@ class CheckResultData extends Data
     ) {
     }
 
+    public function getOutput(): string
+    {
+        return $this->output;
+    }
+
     public function getResultStatus(): string
     {
         return match ($this->exitCode) {

--- a/app/Services/SolutionChecker.php
+++ b/app/Services/SolutionChecker.php
@@ -30,7 +30,10 @@ class SolutionChecker
         Storage::put($userSolutionPath, $contents);
         $solutionPath = Storage::path($userSolutionPath);
         // todo необходимо перейти на новые компоненты laravel 10
-        $command = new Command("raco test --check-stderr --quiet {$solutionPath}");
+        // Файл сам по себе является harness'ом: строит песочницу racket/sandbox,
+        // прогоняет тесты внутри неё и выставляет exit-код. Внешний `timeout` —
+        // подстраховка на случай зависания вне eval-лимита песочницы.
+        $command = new Command("timeout 20s racket {$solutionPath}");
 
         $command->execute();
 

--- a/make-compose.mk
+++ b/make-compose.mk
@@ -70,7 +70,7 @@ ci:
 
 ci-solutions:
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build ${BUILD_ARGS}
-	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci run --rm application make install-app test-solutions
+	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci run --rm application make install-app test-solutions test-sandbox
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci down -v --remove-orphans
 
 stage-setup:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,9 @@
     <testsuite name="Exercises">
       <directory suffix="Test.php">./tests/Exercises</directory>
     </testsuite>
+    <testsuite name="Sandbox">
+      <directory suffix="Test.php">./tests/Sandbox</directory>
+    </testsuite>
   </testsuites>
   <php>
     <env name="APP_ENV" value="testing"/>

--- a/resources/views/exercise/solution_sandbox_wrapper.blade.php
+++ b/resources/views/exercise/solution_sandbox_wrapper.blade.php
@@ -1,13 +1,32 @@
 #lang racket
 (require racket/sandbox)
 
-(define base-module-eval
-(make-module-evaluator '(module m racket/base
-(require rackunit)
+;; Решение студента исполняется в песочнице racket/sandbox с жёсткими лимитами:
+;;  - sandbox-memory-limit / sandbox-eval-limits ограничивают память и время (CPU),
+;;    что убивает бесконечные циклы и попытки исчерпать память (майнеры);
+;;  - дефолтный sandbox-security-guard запрещает сеть, запуск процессов (subprocess/system)
+;;    и доступ к произвольным файлам;
+;;  - sandbox-make-code-inspector отрезает unsafe-операции.
+;; Любое нарушение лимита или ошибка кода студента дают exit-код 1 (tests_failed),
+;; успешный прогон всех проверок — exit-код 0 (success). Контракт совпадает с App\DTO\CheckResultData.
+(with-handlers ([exn:fail:resource? (lambda (e) (printf "~a\n" (exn-message e)) (exit 1))]
+                [exn:fail? (lambda (e) (printf "~a\n" (exn-message e)) (exit 1))])
+  (parameterize ([sandbox-memory-limit 256]
+                 [sandbox-eval-limits (list 10 128)]
+                 [sandbox-make-code-inspector make-inspector])
+    (make-module-evaluator
+     '(module m racket/base
+        (require rackunit)
 ;;; BEGIN
 {!! $solution !!}
 ;;; END
+        (define __sicp_tests_failed (box #f))
+        (define __sicp_default_check_handler (current-check-handler))
+        (current-check-handler
+         (lambda (__sicp_failure)
+           (set-box! __sicp_tests_failed #t)
+           (__sicp_default_check_handler __sicp_failure)))
 {!! $tests !!}
-)
-)
-)
+        (when (unbox __sicp_tests_failed)
+          (error "exercise tests failed"))))
+    (exit 0)))

--- a/tests/Sandbox/SandboxSecurityTest.php
+++ b/tests/Sandbox/SandboxSecurityTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Sandbox;
+
+use App\Models\Exercise;
+use App\Services\SolutionChecker;
+use Database\Seeders\ChaptersTableSeeder;
+use Database\Seeders\ExercisesTableSeeder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Проверяет, что код студента исполняется в изолированной песочнице racket/sandbox:
+ * нет доступа к сети, запуску процессов, файловой системе, а превышение лимитов
+ * по времени/памяти убивает выполнение, а не роняет сам сервис проверки.
+ *
+ * К каждому вредоносному сниппету дописывается корректное эталонное решение, чтобы
+ * модуль скомпилировался и опасная операция реально выполнилась. Если песочница её
+ * НЕ заблокирует — тесты упражнения пройдут (exit 0) и проверка `isFailedTests()`
+ * упадёт, сигнализируя о регрессии изоляции.
+ */
+class SandboxSecurityTest extends TestCase
+{
+    private SolutionChecker $solutionChecker;
+    private Exercise $exercise;
+    private string $teacherSolution;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(ChaptersTableSeeder::class);
+        $this->seed(ExercisesTableSeeder::class);
+
+        $this->solutionChecker = new SolutionChecker();
+        $this->exercise = Exercise::all()
+            ->first(fn(Exercise $exercise) => $exercise->hasTests() && $exercise->hasTeacherSolution());
+        $this->teacherSolution = $this->exercise->getExerciseTeacherSolution();
+    }
+
+    private function attack(string $maliciousCode): string
+    {
+        return "{$maliciousCode}\n{$this->teacherSolution}";
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function maliciousSolutionsProvider(): array
+    {
+        return [
+            'network access' => ['(require racket/tcp) (tcp-connect "example.com" 80)'],
+            'system command' => ['(require racket/system) (system "id")'],
+            'subprocess spawn' => ['(require racket/system) (subprocess #f #f #f "/bin/ls")'],
+            'infinite loop (cpu)' => ['(let loop () (loop))'],
+            'memory exhaustion' => ['(define __v (make-vector 1000000000 0)) (vector-ref __v 0)'],
+            'read arbitrary file' => ['(require racket/file) (file->string "/etc/passwd")'],
+        ];
+    }
+
+    #[DataProvider('maliciousSolutionsProvider')]
+    public function testMaliciousSolutionIsBlocked(string $maliciousCode): void
+    {
+        $checkResult = $this->solutionChecker->check($this->exercise, $this->attack($maliciousCode));
+
+        $this->assertTrue(
+            $checkResult->isFailedTests(),
+            "Вредоносный код должен быть заблокирован песочницей (exit 1), а не уронить чек.\n"
+            . "Статус: {$checkResult->getResultStatus()}\nВывод: {$checkResult->getOutput()}"
+        );
+    }
+
+    public function testFileWriteIsBlockedAndNoFileCreated(): void
+    {
+        $target = sys_get_temp_dir() . '/sicp-sandbox-pwned-' . uniqid();
+        $maliciousCode = sprintf(
+            '(call-with-output-file "%s" (lambda (out) (display "pwned" out)) #:exists (quote replace))',
+            $target
+        );
+
+        $checkResult = $this->solutionChecker->check($this->exercise, $this->attack($maliciousCode));
+
+        $this->assertTrue($checkResult->isFailedTests(), 'Запись файла должна быть заблокирована.');
+        $this->assertFileDoesNotExist($target, 'Студент не должен мочь создать файл на диске.');
+    }
+}


### PR DESCRIPTION
## Проблема

Код студента исполнялся практически без изоляции: в `solution_sandbox_wrapper.blade.php` создавался `make-module-evaluator` из `racket/sandbox`, но **без единого параметра ограничений** — ни лимитов памяти/времени, ни явного запрета сети и `subprocess`. Студент мог ходить по сети, спавнить процессы (майнеры), жечь CPU и память.

## Что сделано

**Песочница (`solution_sandbox_wrapper.blade.php`)** — wrapper стал самодостаточным harness'ом с жёсткими лимитами:
- `sandbox-memory-limit` + `sandbox-eval-limits` → убивают вечные циклы (CPU) и попытки исчерпать память;
- дефолтный `sandbox-security-guard` → запрет сети, `subprocess`/`system`, доступа к произвольным файлам;
- `sandbox-make-code-inspector` → отрезает unsafe-операции;
- провал любого `check-*` печатает все ошибки и даёт exit 1, успех — 0. Контракт `CheckResultData` (0/1/прочее) не меняется.

**`SolutionChecker`** — запускает файл как `timeout 20s racket` вместо `raco test` (harness сам выставляет exit-код; внешний `timeout` — подстраховка от зависания вне eval-лимита).

**`CheckResultData::getOutput()`** — починен latent-баг: метод вызывали `TeacherSolutionsTest` и `ExerciseService`, но его не существовало (`Call to undefined method`).

**Новый testsuite `Sandbox`** (`tests/Sandbox/SandboxSecurityTest`) — вредоносные сниппеты (сеть, `system`/`subprocess`, вечный цикл, гигабайт памяти, чтение/запись файлов), отдельно от `Exercises` (там только проверка эталонных решений). Гоняется в CI рядом с `test-solutions`.

## Проверка

Прогнал **точный отрендеренный файл** (с реальным 28-пробельным отступом `prettifyCode`) через `racket/racket:8.17-full`:

| Сценарий | Результат |
|---|---|
| правильное решение | exit 0 |
| неверное решение | печать всех провалов + exit 1 |
| `tcp-connect` | `network access denied`, exit 1 |
| `system`/`subprocess` | `execute access denied`, exit 1 |
| вечный цикл | `out of time`, exit 1 |
| гигабайт памяти | `out of memory`, exit 1 |
| запись файла | `denied`, файл не создан, exit 1 |
| чтение `/etc/passwd` | `read access denied`, exit 1 |
| `(require rackunit)` / `(require sicp)` | работают |

Запуск suite'а с racket: `make test-sandbox` (в Docker/CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)